### PR TITLE
Debug no start

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
               <!--
                   change to "console" for debugging
               -->
-              <headerType>gui</headerType>
+              <headerType>console</headerType>
               <outfile>target/pipeline-updater-gui.exe</outfile>
               <jar>target/updater-gui-${project.version}-shaded.jar</jar>
               <errTitle>pieline-updater</errTitle>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
       <dependency>
         <groupId>org.daisy.pipeline</groupId>
         <artifactId>framework-bom</artifactId>
-        <version>1.10.2</version>
+        <version>1.10.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/org/daisy/pipeline/updater/gui/Main.java
+++ b/src/main/java/org/daisy/pipeline/updater/gui/Main.java
@@ -22,13 +22,22 @@ public class Main extends Application {
     
     @Override
     public void start(final Stage primaryStage) {
-
             String pipelineHome; {
                     pipelineHome = null;
+					String jvmBit = System.getProperty("sun.arch.data.model");
                     try {
-                            pipelineHome = Advapi32Util.registryGetStringValue(
-                                                WinReg.HKEY_LOCAL_MACHINE, "SOFTWARE\\DAISY Pipeline 2", "Pipeline2Home");
-                    } catch (Win32Exception e) {
+							if (jvmBit.equals("32")) {
+								System.err.println("32-bit JRE detected, looking for home in SOFTWARE/DAISY Pipeline 2");
+								pipelineHome = Advapi32Util.registryGetStringValue(
+												WinReg.HKEY_LOCAL_MACHINE, "SOFTWARE\\DAISY Pipeline 2", "Pipeline2Home");
+							} else if (jvmBit.equals("64")) {
+								System.err.println("64-bit JRE detected, looking for home in SOFTWARE/WOW6432Node/DAISY Pipeline 2");
+								pipelineHome = Advapi32Util.registryGetStringValue(
+												WinReg.HKEY_LOCAL_MACHINE, "SOFTWARE\\WOW6432Node\\DAISY Pipeline 2", "Pipeline2Home");
+							}
+					} catch (Win32Exception e) {
+						System.err.println("Win32Exception" + e.getMessage());
+						e.printStackTrace();
                     }
                     if (Strings.isNullOrEmpty(pipelineHome)) {
                             pipelineHome = System.getenv("PIPELINE2_HOME");


### PR DESCRIPTION
Fix for issue https://github.com/daisy/pipeline-assembly/issues/136 in which the `Pipeline2Home` registry entry wasn't being found when the user is running a 64-bit JVM.